### PR TITLE
Added palindrome related definitions and lemmas

### DIFF
--- a/lib/Seq.dfy
+++ b/lib/Seq.dfy
@@ -289,37 +289,27 @@ module Seq {
 
   /***** Palindrome *****/
   predicate palindrome?<T>(s : seq<T>) {
-  if |s| <= 1 then true else (s[0] == s[|s|-1] && palindrome?(s[1..|s|-1]))
-}
+    if |s| <= 1 then true else (s[0] == s[|s|-1] && palindrome?(s[1..|s|-1]))
+  }
 
-lemma palindromeOne<T>(s: seq<T>)
-requires |s| == 1
-ensures palindrome?(s)
-{}
+  lemma palindromeOne<T>(s: seq<T>)
+    requires |s| == 1
+    ensures palindrome?(s)
+  {}
 
-lemma palindromeIndex<T>(s: seq<T>)
-requires palindrome?(s)
-ensures forall i :: 0 <= i < |s| ==> s[i] == s[|s|-1-i]
-{}
+  lemma palindromeIndex<T>(s: seq<T>)
+    requires palindrome?(s)
+    ensures forall i :: 0 <= i < |s| ==> s[i] == s[|s|-1-i]
+  {}
 
-
-lemma palindromToReverse<T>(s: seq<T>)
-requires palindrome?(s)
-ensures Reverse(s) == s
-{
-  palindromeIndex(s);
-  ReverseIndexAll(s);
-  //ReverseIndexAll(Reverse(s));
-}
-
-/*
-lemma reverseToPalindrome<T>(s: seq<T>)
-requires Reverse(s) == s
-ensures palindrome?(s)
-{
-  ReverseIndexAll(s);
-  ReverseIndexAll(Reverse(s));
-}
-*/
+  lemma palindromRelReverse<T>(s: seq<T>)
+    ensures palindrome?(s) <==> Reverse(s) == s
+  {
+    if |s| > 1 {
+      var t := s[1..|s| - 1];
+      ReverseIndexAll(s);
+      ReverseIndexAll(t);
+    }
+  }
 
 }

--- a/lib/Seq.dfy
+++ b/lib/Seq.dfy
@@ -287,4 +287,39 @@ module Seq {
   {
   }
 
+  /***** Palindrome *****/
+  predicate palindrome?<T>(s : seq<T>) {
+  if |s| <= 1 then true else (s[0] == s[|s|-1] && palindrome?(s[1..|s|-1]))
+}
+
+lemma palindromeOne<T>(s: seq<T>)
+requires |s| == 1
+ensures palindrome?(s)
+{}
+
+lemma palindromeIndex<T>(s: seq<T>)
+requires palindrome?(s)
+ensures forall i :: 0 <= i < |s| ==> s[i] == s[|s|-1-i]
+{}
+
+
+lemma palindromToReverse<T>(s: seq<T>)
+requires palindrome?(s)
+ensures Reverse(s) == s
+{
+  palindromeIndex(s);
+  ReverseIndexAll(s);
+  //ReverseIndexAll(Reverse(s));
+}
+
+/*
+lemma reverseToPalindrome<T>(s: seq<T>)
+requires Reverse(s) == s
+ensures palindrome?(s)
+{
+  ReverseIndexAll(s);
+  ReverseIndexAll(Reverse(s));
+}
+*/
+
 }

--- a/lib/Seq.dfy
+++ b/lib/Seq.dfy
@@ -286,30 +286,4 @@ module Seq {
     ensures Distinct(xs)
   {
   }
-
-  /***** Palindrome *****/
-  predicate palindrome?<T>(s : seq<T>) {
-    if |s| <= 1 then true else (s[0] == s[|s|-1] && palindrome?(s[1..|s|-1]))
-  }
-
-  lemma palindromeOne<T>(s: seq<T>)
-    requires |s| == 1
-    ensures palindrome?(s)
-  {}
-
-  lemma palindromeIndex<T>(s: seq<T>)
-    requires palindrome?(s)
-    ensures forall i :: 0 <= i < |s| ==> s[i] == s[|s|-1-i]
-  {}
-
-  lemma palindromRelReverse<T>(s: seq<T>)
-    ensures palindrome?(s) <==> Reverse(s) == s
-  {
-    if |s| > 1 {
-      var t := s[1..|s| - 1];
-      ReverseIndexAll(s);
-      ReverseIndexAll(t);
-    }
-  }
-
 }

--- a/lib/seq/Palindrome.dfy
+++ b/lib/seq/Palindrome.dfy
@@ -1,0 +1,38 @@
+// Author: Shaobo He
+
+include "../Seq.dfy"
+
+import opened Seq
+
+/***** Palindrome *****/
+predicate Palindrome?<T>(s: seq<T>) {
+  if |s| <= 1 then true else (s[0] == s[|s|-1] && Palindrome?(s[1..|s|-1]))
+}
+
+lemma OneCharStringIsPalindrome<T>(s: seq<T>)
+ensures |s| == 1 ==> Palindrome?(s)
+{}
+
+lemma PalindromeIndex<T>(s: seq<T>)
+requires Palindrome?(s)
+ensures forall i :: 0 <= i < |s| ==> s[i] == s[|s|-1-i]
+{
+}
+
+lemma PalindromIndexImp<T>(s: seq<T>)
+ensures Palindrome?(s) ==> (forall i :: 0 <= i < |s| ==> s[i] == s[|s|-1-i])
+{
+  if Palindrome?(s) {
+    PalindromeIndex(s);
+  }
+}
+
+lemma PalindromRelReverse<T>(s: seq<T>)
+ensures Palindrome?(s) <==> Reverse(s) == s
+{
+  if |s| > 1 {
+    var t := s[1..|s| - 1];
+    ReverseIndexAll(s);
+    ReverseIndexAll(t);
+  }
+}


### PR DESCRIPTION
Hi Alexey,

I'm trying to add palindrome-related stuff to the sequence library. Currently, I'm working on the lemma that states a sequence being a palindrome equates to it equal to its reverse. I split it into two lemmas and the lemma `reverseToPalindrome` causes Dafny on my desktop to hang forever. Could you take a look at it? 