### PR TITLE
Add a simple CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+name: check proofs
+
+on: [push, pull_request]
+
+jobs:
+  check-proofs:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        test_dir:
+          [
+            ".",
+            "leetcode",
+            "lib/math",
+            "lib/seq",
+            "lib",
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: install danfy
+        run: |
+          wget -q https://github.com/dafny-lang/dafny/releases/download/v3.6.0/dafny-3.6.0-x64-ubuntu-16.04.zip
+          unzip -qq dafny-3.6.0-x64-ubuntu-16.04.zip
+          echo "dafny=$PWD/dafny/dafny" >> $GITHUB_ENV
+      - name: test
+        env:
+          DAFNY: "${{ env.dafny }}"
+          TEST_DIR: "${{ matrix.test_dir }}"
+        run: |
+          for b in $(ls $TEST_DIR/*.dfy)
+          do
+            echo $b
+            if [[ "$b" == *"[wip]"* ]]
+            then
+              echo "Ignore working in progress proof: "$b
+            else
+              $DAFNY $b /compile:0
+            fi
+            echo "================================================"
+          done

--- a/lib/seq/timeouts/Digits.dfy
+++ b/lib/seq/timeouts/Digits.dfy
@@ -1,5 +1,5 @@
 include "../Seq.dfy"
-include "../Math/DivMod.dfy"
+include "../math/DivMod.dfy"
 
 module DigitsModule {
 


### PR DESCRIPTION
This PR added a simple CI for the examples. It basically iterates all the `.dfy` files under a certain directory (specified in the `test_dir` variables) and invokes Dafny to run them. In addition, any files containing `[wip]` in their names will be ignored and the program `Digits.dfy`  times out on my desktop as well as on the CI VM, so I moved it into a `timeout` folder.